### PR TITLE
Add alpha csv output

### DIFF
--- a/seir_opt.py
+++ b/seir_opt.py
@@ -955,6 +955,7 @@ def o_optimize_output(l,z,i):
                 fn.write("  " + str(V_table[a, t, i_opt, j_opt]) + "  ")
             fn.write("\n")
         
+        
 def o_simulate_csvwriter(t_sim,S,S_V,E,E_V,D,R,W,V_star,alpha):
     """ Outputs to CSV for simulation only
     """


### PR DESCRIPTION
9. Add alpha[a, t] to format of CSV files.  

a) Make alpha[a, t] an argumant of o.writecsv(). Because it is qa local variable in main(), solve_LP(), and simulate() it can’t be made global. 

b) When writing csv, for optimize and simulate: 

- In the header, replace “H” with “alpha” 

- In the other rows, delete 0 (the value given to H) and insert alpha[a, t] before V_table 